### PR TITLE
Add Ceph Storage Device Telemetry dataset

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,6 +142,7 @@ A curated list of awesome academic researches and industrial materials about Art
 - [Google] [Cluster Traces](https://github.com/google/cluster-data)
 - [Backblaze] [Hard Drive Dataset](https://www.backblaze.com/b2/hard-drive-test-data.html)
 - [Baidu] [SMART Dataset of PAKDD CUP 2020](https://pan.baidu.com/share/link?shareid=189977&uk=4278294944#list/path=%2FS.M.A.R.T.dataset)
+- [Red Hat] [Ceph Device Telemetry Dataset](https://ceph.io/en/users/telemetry/device-telemetry/)
 
 
 ## Others


### PR DESCRIPTION
Adds the open source Ceph Telemetry dataset, which consists of SMART metrics collected from hard disks running in a variety of Ceph storage clusters.